### PR TITLE
Replace syslog with go-syslog

### DIFF
--- a/executor/helm_integration_test.go
+++ b/executor/helm_integration_test.go
@@ -26,6 +26,12 @@ import (
 
 func hasHelmBinary(executor os.OsExecutor) error {
 	_, _, err := executor.Execute("helm", nil, nil, "")
+	if err != nil {
+		return err
+	}
+
+	// HACK: Since we only support helm ~ 2.9.x
+	_, _, err = executor.Execute("helm --version | grep 2.9", nil, nil, "")
 	return err
 }
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ require (
 	github.com/elliotchance/orderedmap v1.2.0
 	github.com/golang/protobuf v1.3.2 // indirect
 	github.com/googleapis/gnostic v0.2.0 // indirect
+	github.com/hashicorp/go-syslog v1.0.0
 	github.com/hashicorp/vault/api v1.0.1
 	github.com/imdario/mergo v0.3.7 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
@@ -14,6 +15,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/palantir/stacktrace v0.0.0-20161112013806-78658fd2d177
+	github.com/pkg/errors v0.8.1
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,8 @@ github.com/hashicorp/go-rootcerts v1.0.0 h1:Rqb66Oo1X/eSV1x66xbDccZjhJigjg0+e82k
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
 github.com/hashicorp/go-sockaddr v1.0.2 h1:ztczhD1jLxIRjVejw8gFomI1BQZOe2WoVOu0SyteCQc=
 github.com/hashicorp/go-sockaddr v1.0.2/go.mod h1:rB4wwRAUzs07qva3c5SdrY/NEtAUjGlgmH/UkBUC97A=
+github.com/hashicorp/go-syslog v1.0.0 h1:KaodqZuhUoZereWVIYmpUgZysurB1kBLX2j0MwMrUAE=
+github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1 h1:fv1ep09latC32wFoVwnqcnKJGnMSdBanPczbHAYm1BE=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=

--- a/logger/zap_syslog_core.go
+++ b/logger/zap_syslog_core.go
@@ -1,0 +1,76 @@
+package logger
+
+import (
+	gsyslog "github.com/hashicorp/go-syslog"
+	"github.com/pkg/errors"
+	"go.uber.org/zap/zapcore"
+)
+
+type ZapSyslogCore struct {
+	zapcore.LevelEnabler
+	encoder zapcore.Encoder
+	writer  gsyslog.Syslogger
+}
+
+func NewZapSyslogCore(enab zapcore.LevelEnabler, encoder zapcore.Encoder, writer gsyslog.Syslogger) *ZapSyslogCore {
+	return &ZapSyslogCore{
+		LevelEnabler: enab,
+		encoder:      encoder,
+		writer:       writer,
+	}
+}
+
+func (core *ZapSyslogCore) With(fields []zapcore.Field) zapcore.Core {
+	clone := core.clone()
+	for _, field := range fields {
+		field.AddTo(clone.encoder)
+	}
+	return clone
+}
+
+// NOTE: We pass `entry` by value to satisfy the interface requirements
+// nolint:gocritic
+func (core *ZapSyslogCore) Check(entry zapcore.Entry, checked *zapcore.CheckedEntry) *zapcore.CheckedEntry {
+	if core.Enabled(entry.Level) {
+		return checked.AddCore(entry, core)
+	}
+	return checked
+}
+
+// NOTE: We pass `entry` by value to satisfy the interface requirements
+// nolint:gocritic
+func (core *ZapSyslogCore) Write(entry zapcore.Entry, fields []zapcore.Field) error {
+	buffer, err := core.encoder.EncodeEntry(entry, fields)
+	if err != nil {
+		return errors.Wrap(err, "failed to encode log entry")
+	}
+
+	message := buffer.Bytes()
+
+	switch entry.Level {
+	case zapcore.DebugLevel:
+		return core.writer.WriteLevel(gsyslog.LOG_DEBUG, message)
+	case zapcore.InfoLevel:
+		return core.writer.WriteLevel(gsyslog.LOG_INFO, message)
+	case zapcore.WarnLevel:
+		return core.writer.WriteLevel(gsyslog.LOG_WARNING, message)
+	case zapcore.ErrorLevel:
+		return core.writer.WriteLevel(gsyslog.LOG_ERR, message)
+	case zapcore.DPanicLevel, zapcore.PanicLevel, zapcore.FatalLevel:
+		return core.writer.WriteLevel(gsyslog.LOG_CRIT, message)
+	default:
+		return errors.Errorf("unknown log level: %v", entry.Level)
+	}
+}
+
+func (core *ZapSyslogCore) Sync() error {
+	return nil
+}
+
+func (core *ZapSyslogCore) clone() *ZapSyslogCore {
+	return &ZapSyslogCore{
+		LevelEnabler: core.LevelEnabler,
+		encoder:      core.encoder.Clone(),
+		writer:       core.writer,
+	}
+}


### PR DESCRIPTION
go-syslog has deadlines when writing locally or over the write,
 hence fixing the official syslog's bug to hang when syslog breaks.

Also provides cross-compilation support, which saves us time from
 writing our own abstraction to be able to compile on windows.