### PR TITLE
Fix close RMQ channel

### DIFF
--- a/rabbitmq/consumer.go
+++ b/rabbitmq/consumer.go
@@ -140,8 +140,13 @@ func (c *Consumer) handleDeliveries(
 		select {
 		case <-ctx.Done():
 			c.logger.Warn("RMQ handler stopping")
-			return nil
-		case d := <-deliveries:
+			return ctx.Err()
+		case d, hasMore := <-deliveries:
+			if !hasMore {
+				c.logger.Warn("RMQ handler deliveries channel closed.")
+				continue
+			}
+
 			// TODO: Add option to parallelize processing
 			c.stopWg.Add(1)
 			err := c.handleSingleDelivery(ctx, &d)


### PR DESCRIPTION
When RMQ is closed from the server side an empty message is received due to the semantics of Golang's `close(ch)`. 

We can check if the message is the last one and skip processing it.