### PR TITLE
Add cache-from for docker build

### DIFF
--- a/executor/docker.go
+++ b/executor/docker.go
@@ -38,6 +38,7 @@ type DockerBuildOptions struct {
 	File       string
 	Tag        string
 	Target     string
+	CacheFrom  []string
 	ContextDir string
 }
 
@@ -82,6 +83,12 @@ func (docker *Docker) buildArgs(options *DockerBuildOptions) []string {
 
 	if options.Target != "" {
 		args = append(args, "--target", options.Target)
+	}
+
+	if options.CacheFrom != nil {
+		for _, cacheFrom := range options.CacheFrom {
+			args = append(args, "--cache-from", cacheFrom)
+		}
 	}
 
 	if options.Hosts != nil {

--- a/executor/docker_test.go
+++ b/executor/docker_test.go
@@ -390,6 +390,82 @@ func TestDocker_Build(t *testing.T) {
 		},
 	)
 
+	t.Run(
+		"when buildings succeeds and `options.CacheFrom` have exactly one cache from image, "+
+			"it docker builds specified file, adds the cache from image and tags to specified tag",
+		func(t *testing.T) {
+			executorArg := &ostest.FakeOsExecutor{}
+
+			optionsArg := &DockerBuildOptions{
+				File:       "./examplefile",
+				CacheFrom:  []string{"example-image:tag"},
+				ContextDir: ".",
+				Tag:        "mytag",
+			}
+
+			executorArg.On(
+				"ExecuteContext",
+				context.Background(),
+				"docker",
+				[]string{
+					"build",
+					"-f",
+					optionsArg.File,
+					"--tag",
+					optionsArg.Tag,
+					"--cache-from",
+					optionsArg.CacheFrom[0],
+					optionsArg.ContextDir,
+				},
+				[]string(nil),
+				"",
+			).Return([]byte{}, []byte{}, nil)
+
+			dockerInstance := NewDocker(executorArg)
+			actual := dockerInstance.Build(context.Background(), optionsArg)
+			require.Nil(t, actual)
+		},
+	)
+
+	t.Run(
+		"when buildings succeeds and `options.CacheFrom` have more than one cache from image, "+
+			"it docker builds specified file, adds the cache from image and tags to specified tag",
+		func(t *testing.T) {
+			executorArg := &ostest.FakeOsExecutor{}
+
+			optionsArg := &DockerBuildOptions{
+				File:       "./examplefile",
+				CacheFrom:  []string{"example-image:tag1", "example-image:tag2"},
+				ContextDir: ".",
+				Tag:        "mytag",
+			}
+
+			executorArg.On(
+				"ExecuteContext",
+				context.Background(),
+				"docker",
+				[]string{
+					"build",
+					"-f",
+					optionsArg.File,
+					"--tag",
+					optionsArg.Tag,
+					"--cache-from",
+					optionsArg.CacheFrom[0],
+					"--cache-from",
+					optionsArg.CacheFrom[1],
+					optionsArg.ContextDir,
+				},
+				[]string(nil),
+				"",
+			).Return([]byte{}, []byte{}, nil)
+
+			dockerInstance := NewDocker(executorArg)
+			actual := dockerInstance.Build(context.Background(), optionsArg)
+			require.Nil(t, actual)
+		},
+	)
+
 }
 
 func TestDocker_Login(t *testing.T) {


### PR DESCRIPTION
Add cache-from arguments to the docker build command so that we can make use of docker caching while building images