### PR TITLE
Add typed error when RabbitMQ producer closes the connection

### DIFF
--- a/rabbitmq/producer.go
+++ b/rabbitmq/producer.go
@@ -25,7 +25,7 @@ import (
 	"github.com/sumup-oss/go-pkgs/logger"
 )
 
-var ProducerError = errors.New("RMQ producer has already closed the connection")
+var ErrProducerConnection = errors.New("RMQ producer has already closed the connection")
 
 type Producer struct {
 	client  *RabbitMQClient
@@ -80,7 +80,7 @@ func (p *Producer) Publish(
 		p.isClosed = true
 	default:
 		if p.isClosed {
-			return stacktrace.Propagate(ProducerError, "RabbitMQ connection closed")
+			return stacktrace.Propagate(ErrProducerConnection, "RabbitMQ connection closed")
 		}
 
 		err := p.channel.Publish(

--- a/rabbitmq/producer.go
+++ b/rabbitmq/producer.go
@@ -16,6 +16,7 @@ package rabbitmq
 
 import (
 	"context"
+	"errors"
 
 	"github.com/palantir/stacktrace"
 	"github.com/streadway/amqp"
@@ -23,6 +24,8 @@ import (
 
 	"github.com/sumup-oss/go-pkgs/logger"
 )
+
+var ProducerError = errors.New("RMQ producer has already closed the connection")
 
 type Producer struct {
 	client  *RabbitMQClient
@@ -77,7 +80,7 @@ func (p *Producer) Publish(
 		p.isClosed = true
 	default:
 		if p.isClosed {
-			return stacktrace.NewError("RMQ producer has already closed the connection")
+			return stacktrace.Propagate(ProducerError, "RabbitMQ connection closed")
 		}
 
 		err := p.channel.Publish(


### PR DESCRIPTION
Add typed error when producer closes the connection so after that in the client we can check if stacktrace.RootCause(err) == rabbitmq.ProducerError