### PR TITLE
rabbitmq - Consume/Publish CorrelationId

### DIFF
--- a/rabbitmq/consumer.go
+++ b/rabbitmq/consumer.go
@@ -171,7 +171,7 @@ func (c *Consumer) handleSingleDelivery(ctx context.Context, d *amqp.Delivery) e
 
 	acknowledgement, err := c.handler.ReceiveMessage(ctx, &Message{
 		Body:          d.Body,
-		CorrelationId: d.CorrelationId,
+		CorrelationID: d.CorrelationId,
 	})
 	if err != nil {
 		return stacktrace.Propagate(err, "handler returned error")

--- a/rabbitmq/consumer.go
+++ b/rabbitmq/consumer.go
@@ -158,14 +158,6 @@ func (c *Consumer) handleDeliveries(
 	}
 }
 
-func tracingField(d *amqp.Delivery) zap.Field {
-	if d.CorrelationId == "" {
-		return zap.Skip()
-	}
-
-	return zap.String("tracing_id", d.CorrelationId)
-}
-
 func (c *Consumer) handleSingleDelivery(ctx context.Context, d *amqp.Delivery) error {
 	c.metric.ObserveMsgDelivered()
 
@@ -190,7 +182,7 @@ func (c *Consumer) handleSingleDelivery(ctx context.Context, d *amqp.Delivery) e
 			c.logger.Error(
 				"failed to ack message",
 				zap.Error(err),
-				tracingField(d),
+				tracingField(d.CorrelationId),
 			)
 
 			if c.handler.MustStopOnAckError() {
@@ -203,7 +195,7 @@ func (c *Consumer) handleSingleDelivery(ctx context.Context, d *amqp.Delivery) e
 		c.metric.ObserveAck(true)
 		c.logger.Info(
 			"successful ack message",
-			tracingField(d),
+			tracingField(d.CorrelationId),
 		)
 		return nil
 	case Nack:
@@ -213,7 +205,7 @@ func (c *Consumer) handleSingleDelivery(ctx context.Context, d *amqp.Delivery) e
 			c.logger.Error(
 				"failed to nack message",
 				zap.Error(err),
-				tracingField(d),
+				tracingField(d.CorrelationId),
 			)
 
 			if c.handler.MustStopOnNAckError() {
@@ -226,7 +218,7 @@ func (c *Consumer) handleSingleDelivery(ctx context.Context, d *amqp.Delivery) e
 		c.metric.ObserveNack(true)
 		c.logger.Info(
 			"successful nack message",
-			tracingField(d),
+			tracingField(d.CorrelationId),
 		)
 
 		return nil
@@ -237,7 +229,7 @@ func (c *Consumer) handleSingleDelivery(ctx context.Context, d *amqp.Delivery) e
 			c.logger.Error(
 				"failed to reject message",
 				zap.Error(err),
-				tracingField(d),
+				tracingField(d.CorrelationId),
 			)
 
 			if c.handler.MustStopOnRejectError() {
@@ -249,7 +241,7 @@ func (c *Consumer) handleSingleDelivery(ctx context.Context, d *amqp.Delivery) e
 		c.metric.ObserveReject(true)
 		c.logger.Info(
 			"successful rejected message",
-			tracingField(d),
+			tracingField(d.CorrelationId),
 		)
 
 		return nil

--- a/rabbitmq/consumer.go
+++ b/rabbitmq/consumer.go
@@ -169,8 +169,10 @@ func tracingField(d *amqp.Delivery) zap.Field {
 func (c *Consumer) handleSingleDelivery(ctx context.Context, d *amqp.Delivery) error {
 	c.metric.ObserveMsgDelivered()
 
-	ctx = c.handler.GetConsumeContext(ctx, d)
-	acknowledgement, err := c.handler.ReceiveMessage(ctx, d.Body)
+	acknowledgement, err := c.handler.ReceiveMessage(ctx, &Message{
+		Body:          d.Body,
+		CorrelationId: d.CorrelationId,
+	})
 	if err != nil {
 		return stacktrace.Propagate(err, "handler returned error")
 	}

--- a/rabbitmq/consumer.go
+++ b/rabbitmq/consumer.go
@@ -161,6 +161,7 @@ func (c *Consumer) handleDeliveries(
 func (c *Consumer) handleSingleDelivery(ctx context.Context, d *amqp.Delivery) error {
 	c.metric.ObserveMsgDelivered()
 
+	ctx = c.handler.GetConsumeContext(ctx, d)
 	acknowledgement, err := c.handler.ReceiveMessage(ctx, d.Body)
 	if err != nil {
 		return stacktrace.Propagate(err, "handler returned error")

--- a/rabbitmq/handler.go
+++ b/rabbitmq/handler.go
@@ -14,7 +14,11 @@
 
 package rabbitmq
 
-import "context"
+import (
+	"context"
+
+	"github.com/streadway/amqp"
+)
 
 type Handler interface {
 	GetQueueName() string
@@ -26,6 +30,7 @@ type Handler interface {
 	MustStopOnRejectError() bool
 	WaitToConsumeInflight() bool
 	ReceiveMessage(ctx context.Context, payload []byte) (acknowledgement HandlerAcknowledgement, err error)
+	GetConsumeContext(ctx context.Context, d *amqp.Delivery) context.Context
 }
 
 type AcknowledgementType int

--- a/rabbitmq/handler.go
+++ b/rabbitmq/handler.go
@@ -49,5 +49,5 @@ type Message struct {
 	Body []byte
 
 	// Correlation identifier
-	CorrelationId string
+	CorrelationID string
 }

--- a/rabbitmq/handler.go
+++ b/rabbitmq/handler.go
@@ -45,9 +45,9 @@ type HandlerAcknowledgement struct {
 
 // Message contains data that is specific to the consumed RabbitMQ message
 type Message struct {
-	// Body contains the received message's payload
+	// The application specific payload of the message
 	Body []byte
 
-	// CorrelationId represents the received message's CorrelationId
+	// Correlation identifier
 	CorrelationId string
 }

--- a/rabbitmq/handler.go
+++ b/rabbitmq/handler.go
@@ -16,8 +16,6 @@ package rabbitmq
 
 import (
 	"context"
-
-	"github.com/streadway/amqp"
 )
 
 type Handler interface {
@@ -29,8 +27,7 @@ type Handler interface {
 	MustStopOnNAckError() bool
 	MustStopOnRejectError() bool
 	WaitToConsumeInflight() bool
-	ReceiveMessage(ctx context.Context, payload []byte) (acknowledgement HandlerAcknowledgement, err error)
-	GetConsumeContext(ctx context.Context, d *amqp.Delivery) context.Context
+	ReceiveMessage(ctx context.Context, msg *Message) (acknowledgement HandlerAcknowledgement, err error)
 }
 
 type AcknowledgementType int
@@ -44,4 +41,13 @@ const (
 type HandlerAcknowledgement struct {
 	Acknowledgement AcknowledgementType
 	Requeue         bool
+}
+
+// Message contains data that is specific to the consumed RabbitMQ message
+type Message struct {
+	// Body contains the received message's payload
+	Body []byte
+
+	// CorrelationId represents the received message's CorrelationId
+	CorrelationId string
 }

--- a/rabbitmq/logging.go
+++ b/rabbitmq/logging.go
@@ -1,0 +1,11 @@
+package rabbitmq
+
+import "go.uber.org/zap"
+
+func tracingField(correlationID string) zap.Field {
+	if correlationID == "" {
+		return zap.Skip()
+	}
+
+	return zap.String("tracing_id", correlationID)
+}

--- a/rabbitmq/producer.go
+++ b/rabbitmq/producer.go
@@ -85,10 +85,12 @@ func (p *Producer) Publish(
 				zap.Int("code", rmqErr.Code),
 				zap.Bool("recover", rmqErr.Recover),
 				zap.Bool("server", rmqErr.Server),
+				tracingField(args.CorrelationID),
 			)
 		} else {
 			p.logger.Warn(
 				"RMQ closed the connection without an error",
+				tracingField(args.CorrelationID),
 			)
 		}
 		atomic.CompareAndSwapInt32(&p.isClosed, 0, 1)

--- a/rabbitmq/producer.go
+++ b/rabbitmq/producer.go
@@ -35,7 +35,7 @@ type MessageArgs struct {
 	Headers amqp.Table
 
 	// Correlation identifier
-	CorrelationId string
+	CorrelationID string
 }
 
 type Producer struct {
@@ -104,7 +104,7 @@ func (p *Producer) Publish(
 			immediate,
 			amqp.Publishing{
 				Headers:       args.Headers,
-				CorrelationId: args.CorrelationId,
+				CorrelationId: args.CorrelationID,
 				Expiration:    expiration,
 				Body:          body,
 			},

--- a/rabbitmq/retryable_producer.go
+++ b/rabbitmq/retryable_producer.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/palantir/stacktrace"
-	"github.com/streadway/amqp"
 	"go.uber.org/zap"
 
 	"github.com/sumup-oss/go-pkgs/backoff"
@@ -78,7 +77,7 @@ func (p *RetryableProducer) Publish(
 	immediate bool,
 	expiration string,
 	body []byte,
-	args amqp.Table,
+	args MessageArgs,
 ) error {
 	p.mu.RLock()
 	producer := p.producer


### PR DESCRIPTION
### Description
- Add the ability to access the received message's `CorrelationId`;
- Add the ability to publish a message with a `CorrelationId` field;
- Add logging of the `delivery.CorrelationId` in logger invocations within the `handleSingleDelivery` method in order to be able to group them together;
- Add logging of the `CorrelationId` in logger invocations within the `Publish` method in order to be able to group them together;