### PR TITLE
Fix errors.NewError with nil errors

### DIFF
--- a/errors/README.md
+++ b/errors/README.md
@@ -244,12 +244,12 @@ func Foo() error {
 }
 ```
 
-In that case you can use `NewError`. It just adds stack trace information.
+In that case you can use `Propagate`. It just adds stack trace information.
 
 ```golang
 func Foo() error {
   // returns custom error wrapped with stack trace information.
-  return errors.NewError(NewCustomError("foo failed"))
+  return errors.Propagate(NewCustomError("foo failed"))
 }
 ```
 
@@ -471,7 +471,7 @@ Creating a custom error type is nothing special. You do it the way you usually d
 All the wrap functions and `Is`, `As`, `Unwrap` will work with your custom types.
 
 With a pure custom type if you want to collect stack trace you must return it with one of the
-wrapper functions or using `NewError`.
+wrapper functions or using `Propagate`.
 
 ```golang
 func Foo() error {

--- a/errors/new.go
+++ b/errors/new.go
@@ -33,15 +33,19 @@ func New(format string, a ...interface{}) error {
 	}
 }
 
-// NewError creates a new error from existing error, by wrapping it with stack trace information.
+// Propagate creates a new error from existing error, by wrapping it with stack trace information.
 //
 // Most of the time users should use Wrap, WrapError, Hide and HideError.
 //
 // But sometimes the error does not need wrapping, since it contains enough context.
 // And wrapping will create a chain of two errors with the same description
 // (example: "foo failed: foo failed"). All it is needed is a stack trace.
-// NewError does exactly that, it just adds a stack trace.
-func NewError(err error) error {
+// Propagate does exactly that, it just adds a stack trace.
+func Propagate(err error) error {
+	if err == nil {
+		return nil
+	}
+
 	// The err is already wrapped.
 	wrapped, ok := err.(*wrapError)
 	if ok {

--- a/errors/propagate_example_test.go
+++ b/errors/propagate_example_test.go
@@ -8,11 +8,11 @@ import (
 	"github.com/sumup-oss/go-pkgs/errors"
 )
 
-func ExampleNewError() {
+func ExamplePropagate() {
 	fooError := errors.New("foo failed")
 
 	// Creating error with stack trace without a wrapping string.
-	barErr := errors.NewError(fooError)
+	barErr := errors.Propagate(fooError)
 
 	curDir, _ := os.Getwd()
 
@@ -23,9 +23,9 @@ func ExampleNewError() {
 
 	// Output:
 	// foo failed:
-	//     github.com/sumup-oss/go-pkgs/errors_test.ExampleNewError
-	//         /path/new_error_example_test.go:15
+	//     github.com/sumup-oss/go-pkgs/errors_test.ExamplePropagate
+	//         /path/propagate_example_test.go:15
 	//   - foo failed:
-	//     github.com/sumup-oss/go-pkgs/errors_test.ExampleNewError
-	//         /path/new_error_example_test.go:12
+	//     github.com/sumup-oss/go-pkgs/errors_test.ExamplePropagate
+	//         /path/propagate_example_test.go:12
 }


### PR DESCRIPTION
On nil error errors.NewError must return nil.