### PR TITLE
Add SyncRandomGenerator in the backoff package.

### DIFF
--- a/backoff/backoff.go
+++ b/backoff/backoff.go
@@ -1,15 +1,8 @@
 package backoff
 
 import (
-	"math/rand"
 	"time"
 )
-
-// RandomGenerator interface for the random generator.
-// Standard library can be used as follows: rand.NewSource(time.Now().UnixNano()).
-type RandomGenerator interface {
-	Int63n(n int64) int64
-}
 
 // Config is used for the backoff constructor if you don't want to use the default config.
 type Config struct {
@@ -28,9 +21,31 @@ var DefaultConfig = &Config{
 }
 
 // Backoff is used to calculate the next backoff duration using a Jitter.
+//
 // Check here why to use Jitter - https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
+//
 // The backoff is calculated by min(Max, rand(0, Base*(2^retries))).
-// example: backoffWithDefaultConfig := backoff.New(rand.New(rand.NewSource(time.Now().UnixNano())), backoff.DefaultConfig)
+//
+// Example:
+//	b := backoff.NewBackoff(backoff.DefaultConfig)
+//
+//  for {
+//		err := someFunc()
+//		if err == nil {
+//			// all good
+//			return nil
+//		}
+//
+//		// get the next sleep duration
+//		sleep := b.Next()
+//
+// 		select {
+//		case <-time.After(sleep):
+//			continue
+//		case <-ctx.Done():
+//			return errors.Wrap(err, "retry canceled")
+//		}
+//	}
 type Backoff struct {
 	config *Config
 
@@ -38,7 +53,24 @@ type Backoff struct {
 	retryCount uint
 }
 
+// NewBackoff uses the golang rand generator from the standard library.
+//
+// It is safe to be used in multiple go routines.
+func NewBackoff(config *Config) *Backoff {
+	return NewBackoffWithRandomGen(
+		DefaultRandomGenerator(),
+		config,
+	)
+}
+
 // NewBackoffWithRandomGen is used when you want to pass a custom RandomGenerator.
+//
+// Example:
+//  // Note that the backoff created bellow can be used safely only in a single go routine.
+//	b := backoff.New(
+//		rand.New(rand.NewSource(time.Now().UnixNano())),
+//		backoff.DefaultConfig
+//	)
 func NewBackoffWithRandomGen(randomGen RandomGenerator, config *Config) *Backoff {
 	if config.Base == 0 {
 		config.Base = DefaultConfig.Base
@@ -56,14 +88,6 @@ func NewBackoffWithRandomGen(randomGen RandomGenerator, config *Config) *Backoff
 		config:    config,
 		randomGen: randomGen,
 	}
-}
-
-// NewBackoff uses the golang rand generator from the standard library.
-func NewBackoff(config *Config) *Backoff {
-	return NewBackoffWithRandomGen(
-		rand.New(rand.NewSource(time.Now().UnixNano())), // nolint: gosec
-		config,
-	)
 }
 
 // Next returns the next duration for the retry.

--- a/backoff/random_generator.go
+++ b/backoff/random_generator.go
@@ -1,0 +1,44 @@
+package backoff
+
+import (
+	"math/rand"
+	"sync"
+	"time"
+)
+
+// RandomGenerator interface for the random generator.
+//
+// Standard library can be used as follows: rand.NewSource(time.Now().UnixNano()).
+//
+// Note that the standard generator returned by rand.NewSource is multi go routine unsafe.
+// For multi go routine safety use NewSyncRandomGenerator(rand.NewSource(time.Now().UnixNano())).
+// Or just use the DefaultRandomGenerator function, that returns a go routine safe random generator.
+type RandomGenerator interface {
+	Int63n(n int64) int64
+}
+
+// DefaultRandomGenerator is the default generator used by NewBackoff function.
+func DefaultRandomGenerator() *SyncRandomGenerator {
+	return NewSyncRandomGenerator(rand.New(rand.NewSource(time.Now().UnixNano()))) // nolint: gosec
+}
+
+// SyncRandomGenerator is a wrapper that makes a RandomGenerator multi go routine safe.
+type SyncRandomGenerator struct {
+	RandomGenerator
+	mu sync.Mutex
+}
+
+// NewSyncRandomGenerator creates SyncRandomGenerator instance.
+func NewSyncRandomGenerator(generator RandomGenerator) *SyncRandomGenerator {
+	return &SyncRandomGenerator{
+		RandomGenerator: generator,
+	}
+}
+
+// Int63n returns a int64 random integer in the half open interval [0, n).
+func (g *SyncRandomGenerator) Int63n(n int64) int64 {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	return g.RandomGenerator.Int63n(n)
+}


### PR DESCRIPTION
Update the backoff.NewBackoff to use a default random generator that is
multi go routine safe.