### PR TITLE
Add more configs for accessing docker host

### DIFF
--- a/testutils/git.go
+++ b/testutils/git.go
@@ -43,6 +43,8 @@ const (
 	DefaultExposedGitPort             = 2222
 	DefaultExposedGitBindHost         = "127.0.0.1"
 	DefaultGitDockerDaemonHost        = "unix:///var/run/docker.sock"
+	DefaultGitDockerDaemonCertPath    = ""
+	DefaultGitDockerDaemonTLSVerify   = "1"
 )
 
 type FakeGitServer struct {
@@ -57,8 +59,14 @@ func NewFakeGitServer(
 	port int,
 	dockerContainerName string,
 	dockerDaemonHost string,
+	dockerCertPath string,
+	dockerTLSVerify string,
 ) *FakeGitServer {
-	dockerEnv := []string{fmt.Sprintf("DOCKER_HOST=%s", dockerDaemonHost)}
+	dockerEnv := []string{
+		fmt.Sprintf("DOCKER_HOST=%s", dockerDaemonHost),
+		fmt.Sprintf("DOCKER_CERT_PATH=%s", dockerCertPath),
+		fmt.Sprintf("DOCKER_TLS_VERIFY=%s", dockerTLSVerify),
+	}
 
 	return &FakeGitServer{
 		Host:                host,
@@ -92,12 +100,22 @@ func NewFakeGitServerFromEnv() *FakeGitServer {
 		dockerDaemonHost = DefaultGitDockerDaemonHost
 	}
 
+	dockerDaemonCertPath := os.Getenv("TEST_GIT_DOCKER_CERT_PATH")
+	if dockerDaemonCertPath == "" {
+		dockerDaemonCertPath = DefaultGitDockerDaemonCertPath
+	}
+
+	dockerDaemonTLSVerify := os.Getenv("TEST_GIT_DOCKER_TLS_VERIFY")
+	if dockerDaemonTLSVerify == "" {
+		dockerDaemonTLSVerify = DefaultGitDockerDaemonTLSVerify
+	}
+
 	dockerContainerName := os.Getenv("TEST_GIT_DOCKER_CONTAINER_NAME")
 	if dockerContainerName == "" {
 		dockerContainerName = DefaultFakeGitServerContainerName
 	}
 
-	return NewFakeGitServer(gitHost, gitPortInt, dockerContainerName, dockerDaemonHost)
+	return NewFakeGitServer(gitHost, gitPortInt, dockerContainerName, dockerDaemonHost, dockerDaemonCertPath, dockerDaemonTLSVerify)
 }
 
 func DefaultGitServer() *FakeGitServer {
@@ -106,6 +124,8 @@ func DefaultGitServer() *FakeGitServer {
 		DefaultExposedGitPort,
 		DefaultFakeGitServerContainerName,
 		DefaultGitDockerDaemonHost,
+		DefaultGitDockerDaemonCertPath,
+		DefaultGitDockerDaemonTLSVerify,
 	)
 }
 

--- a/testutils/postgres.go
+++ b/testutils/postgres.go
@@ -27,14 +27,16 @@ import (
 )
 
 const (
-	PostgresDockerImage             = "postgres"
-	DefaultPostgresVersion          = "10"
-	DefaultPostgresDockerDaemonHost = "unix:///var/run/docker.sock"
-	DefaultPostgresHost             = "127.0.0.1"
-	DefaultPostgresPort             = 5432
-	DefaultPostgresUser             = "postgres"
-	DefaultPostgresPassword         = "password"
-	DefaultPostgresDatabase         = "postgres"
+	PostgresDockerImage                  = "postgres"
+	DefaultPostgresVersion               = "10"
+	DefaultPostgresDockerDaemonHost      = "unix:///var/run/docker.sock"
+	DefaultPostgresDockerDaemonCertPath  = ""
+	DefaultPostgresDockerDaemonTLSVerify = "1"
+	DefaultPostgresHost                  = "127.0.0.1"
+	DefaultPostgresPort                  = 5432
+	DefaultPostgresUser                  = "postgres"
+	DefaultPostgresPassword              = "password"
+	DefaultPostgresDatabase              = "postgres"
 )
 
 type FakePostgresServer struct {
@@ -51,6 +53,8 @@ type FakePostgresServer struct {
 func NewFakePostgres10Server(
 	dockerContainerName,
 	dockerDaemonHost,
+	dockerDaemonCertPath,
+	dockerDeamonTLSVerify,
 	host string,
 	port int,
 	user,
@@ -61,6 +65,8 @@ func NewFakePostgres10Server(
 		DefaultPostgresVersion,
 		dockerContainerName,
 		dockerDaemonHost,
+		dockerDaemonCertPath,
+		dockerDeamonTLSVerify,
 		host,
 		port,
 		user,
@@ -93,6 +99,16 @@ func NewFakePostgres10ServerFromEnv() *FakePostgresServer {
 		dockerDaemonHost = DefaultPostgresDockerDaemonHost
 	}
 
+	dockerDaemonCertPath := os.Getenv("TEST_POSTGRES_DOCKER_CERT_PATH")
+	if dockerDaemonCertPath == "" {
+		dockerDaemonCertPath = DefaultPostgresDockerDaemonCertPath
+	}
+
+	dockerDaemonTLSVerify := os.Getenv("TEST_POSTGRES_DOCKER_TLS_VERIFY")
+	if dockerDaemonTLSVerify == "" {
+		dockerDaemonTLSVerify = DefaultPostgresDockerDaemonTLSVerify
+	}
+
 	dockerContainerName := os.Getenv("TEST_POSTGRES_DOCKER_CONTAINER_NAME")
 	if dockerContainerName == "" {
 		panic(`Blank "TEST_POSTGRES_DOCKER_CONTAINER_NAME"`)
@@ -116,6 +132,8 @@ func NewFakePostgres10ServerFromEnv() *FakePostgresServer {
 	return NewFakePostgres10Server(
 		dockerContainerName,
 		dockerDaemonHost,
+		dockerDaemonCertPath,
+		dockerDaemonTLSVerify,
 		host,
 		portInt,
 		user,
@@ -148,6 +166,16 @@ func NewFakePostgresServerFromEnv() *FakePostgresServer {
 		dockerDaemonHost = DefaultPostgresDockerDaemonHost
 	}
 
+	dockerDaemonCertPath := os.Getenv("TEST_POSTGRES_DOCKER_CERT_PATH")
+	if dockerDaemonCertPath == "" {
+		dockerDaemonCertPath = DefaultPostgresDockerDaemonCertPath
+	}
+
+	dockerDaemonTLSVerify := os.Getenv("TEST_POSTGRES_DOCKER_TLS_VERIFY")
+	if dockerDaemonTLSVerify == "" {
+		dockerDaemonTLSVerify = DefaultPostgresDockerDaemonTLSVerify
+	}
+
 	dockerContainerName := os.Getenv("TEST_POSTGRES_DOCKER_CONTAINER_NAME")
 	if dockerContainerName == "" {
 		panic(`Blank "TEST_POSTGRES_DOCKER_CONTAINER_NAME"`)
@@ -178,6 +206,8 @@ func NewFakePostgresServerFromEnv() *FakePostgresServer {
 		postgresVersion,
 		dockerContainerName,
 		dockerDaemonHost,
+		dockerDaemonCertPath,
+		dockerDaemonTLSVerify,
 		host,
 		portInt,
 		user,
@@ -190,13 +220,19 @@ func NewFakePostgresServer(
 	postgresVersion,
 	dockerContainerName,
 	dockerDaemonHost,
+	dockerCertPath,
+	dockerTLSVerify,
 	host string,
 	port int,
 	user,
 	password,
 	database string,
 ) *FakePostgresServer {
-	dockerEnv := []string{fmt.Sprintf("DOCKER_HOST=%s", dockerDaemonHost)}
+	dockerEnv := []string{
+		fmt.Sprintf("DOCKER_HOST=%s", dockerDaemonHost),
+		fmt.Sprintf("DOCKER_CERT_PATH=%s", dockerCertPath),
+		fmt.Sprintf("DOCKER_TLS_VERIFY=%s", dockerTLSVerify),
+	}
 
 	return &FakePostgresServer{
 		host:                host,

--- a/testutils/rabbitmq.go
+++ b/testutils/rabbitmq.go
@@ -27,13 +27,15 @@ import (
 )
 
 const (
-	RabbitMqDockerImage             = "rabbitmq"
-	DefaultRabbitMqVersion          = "3"
-	DefaultRabbitMqDockerDaemonHost = "unix:///var/run/docker.sock"
-	DefaultRabbitMqHost             = "127.0.0.1"
-	DefaultRabbitMqPort             = 5672
-	DefaultRabbitMqUser             = "guest"
-	DefaultRabbitMqPassword         = "guest"
+	RabbitMqDockerImage                  = "rabbitmq"
+	DefaultRabbitMqVersion               = "3"
+	DefaultRabbitMqDockerDaemonHost      = "unix:///var/run/docker.sock"
+	DefaultRabbitMqDockerDaemonCertPath  = ""
+	DefaultRabbitMqDockerDaemonTLSVerify = "1"
+	DefaultRabbitMqHost                  = "127.0.0.1"
+	DefaultRabbitMqPort                  = 5672
+	DefaultRabbitMqUser                  = "guest"
+	DefaultRabbitMqPassword              = "guest"
 )
 
 type FakeRabbitMq struct {
@@ -55,6 +57,16 @@ func NewFakeRabbitMqFromEnv() *FakeRabbitMq {
 	dockerDaemonHost := os.Getenv("TEST_RABBITMQ_DOCKER_HOST")
 	if dockerDaemonHost == "" {
 		dockerDaemonHost = DefaultRabbitMqDockerDaemonHost
+	}
+
+	dockerDaemonCertPath := os.Getenv("TEST_RABBITMQ_DOCKER_CERT_PATH")
+	if dockerDaemonCertPath == "" {
+		dockerDaemonCertPath = DefaultRabbitMqDockerDaemonCertPath
+	}
+
+	dockerDaemonTLSVerify := os.Getenv("TEST_RABBITMQ_DOCKER_TLS_VERIFY")
+	if dockerDaemonTLSVerify == "" {
+		dockerDaemonTLSVerify = DefaultRabbitMqDockerDaemonTLSVerify
 	}
 
 	var portInt int
@@ -95,6 +107,8 @@ func NewFakeRabbitMqFromEnv() *FakeRabbitMq {
 		rabbitmqVersion,
 		dockerContainerName,
 		dockerDaemonHost,
+		dockerDaemonCertPath,
+		dockerDaemonTLSVerify,
 		host,
 		portInt,
 		user,
@@ -116,12 +130,18 @@ func NewFakeRabbitMq(
 	rabbitmqVersion,
 	dockerContainerName,
 	dockerDaemonHost,
+	dockerCertPath,
+	dockerTLSVerify,
 	host string,
 	port int,
 	user,
 	password string,
 ) *FakeRabbitMq {
-	dockerEnv := []string{fmt.Sprintf("DOCKER_HOST=%s", dockerDaemonHost)}
+	dockerEnv := []string{
+		fmt.Sprintf("DOCKER_HOST=%s", dockerDaemonHost),
+		fmt.Sprintf("DOCKER_CERT_PATH=%s", dockerCertPath),
+		fmt.Sprintf("DOCKER_TLS_VERIFY=%s", dockerTLSVerify),
+	}
 
 	return &FakeRabbitMq{
 		host:                host,

--- a/testutils/redis.go
+++ b/testutils/redis.go
@@ -27,11 +27,13 @@ import (
 )
 
 const (
-	RedisDockerImage             = "redis"
-	DefaultRedisVersion          = "5"
-	DefaultRedisDockerDaemonHost = "unix:///var/run/docker.sock"
-	DefaultRedisHost             = "127.0.0.1"
-	DefaultRedisPort             = 6379
+	RedisDockerImage                  = "redis"
+	DefaultRedisVersion               = "5"
+	DefaultRedisDockerDaemonHost      = "unix:///var/run/docker.sock"
+	DefaultRedisDockerDaemonCertPath  = ""
+	DefaultRedisDockerDaemonTLSVerify = "1"
+	DefaultRedisHost                  = "127.0.0.1"
+	DefaultRedisPort                  = 6379
 )
 
 type FakeRedisServer struct {
@@ -45,6 +47,8 @@ type FakeRedisServer struct {
 func NewFakeRedis5Server(
 	dockerContainerName,
 	dockerDaemonHost,
+	dockerDaemonCertPath,
+	dockerDaemonTLSVerify,
 	host string,
 	port int,
 ) *FakeRedisServer {
@@ -52,6 +56,8 @@ func NewFakeRedis5Server(
 		DefaultRedisVersion,
 		dockerContainerName,
 		dockerDaemonHost,
+		dockerDaemonCertPath,
+		dockerDaemonTLSVerify,
 		host,
 		port,
 	)
@@ -81,6 +87,16 @@ func NewFakeRedis5ServerFromEnv() *FakeRedisServer {
 		dockerDaemonHost = DefaultRedisDockerDaemonHost
 	}
 
+	dockerDaemonCertPath := os.Getenv("TEST_REDIS_DOCKER_CERT_PATH")
+	if dockerDaemonCertPath == "" {
+		dockerDaemonCertPath = DefaultRedisDockerDaemonCertPath
+	}
+
+	dockerDaemonTLSVerify := os.Getenv("TEST_REDIS_DOCKER_TLS_VERIFY")
+	if dockerDaemonTLSVerify == "" {
+		dockerDaemonTLSVerify = DefaultRedisDockerDaemonTLSVerify
+	}
+
 	dockerContainerName := os.Getenv("TEST_REDIS_DOCKER_CONTAINER_NAME")
 	if dockerContainerName == "" {
 		panic(`Blank "TEST_REDIS_DOCKER_CONTAINER_NAME"`)
@@ -89,6 +105,8 @@ func NewFakeRedis5ServerFromEnv() *FakeRedisServer {
 	return NewFakeRedis5Server(
 		dockerContainerName,
 		dockerDaemonHost,
+		dockerDaemonCertPath,
+		dockerDaemonTLSVerify,
 		host,
 		portInt,
 	)
@@ -118,6 +136,16 @@ func NewFakeRedisServerFromEnv() *FakeRedisServer {
 		dockerDaemonHost = DefaultRedisDockerDaemonHost
 	}
 
+	dockerDaemonCertPath := os.Getenv("TEST_REDIS_DOCKER_CERT_PATH")
+	if dockerDaemonCertPath == "" {
+		dockerDaemonCertPath = DefaultRedisDockerDaemonCertPath
+	}
+
+	dockerDaemonTLSVerify := os.Getenv("TEST_REDIS_DOCKER_TLS_VERIFY")
+	if dockerDaemonTLSVerify == "" {
+		dockerDaemonTLSVerify = DefaultRedisDockerDaemonTLSVerify
+	}
+
 	dockerContainerName := os.Getenv("TEST_REDIS_DOCKER_CONTAINER_NAME")
 	if dockerContainerName == "" {
 		panic(`Blank "TEST_REDIS_DOCKER_CONTAINER_NAME"`)
@@ -132,6 +160,8 @@ func NewFakeRedisServerFromEnv() *FakeRedisServer {
 		version,
 		dockerContainerName,
 		dockerDaemonHost,
+		dockerDaemonCertPath,
+		dockerDaemonTLSVerify,
 		host,
 		portInt,
 	)
@@ -141,10 +171,16 @@ func NewFakeRedisServer(
 	version,
 	dockerContainerName,
 	dockerDaemonHost,
+	dockerCertPath,
+	dockerTLSVerify,
 	host string,
 	port int,
 ) *FakeRedisServer {
-	dockerEnv := []string{fmt.Sprintf("DOCKER_HOST=%s", dockerDaemonHost)}
+	dockerEnv := []string{
+		fmt.Sprintf("DOCKER_HOST=%s", dockerDaemonHost),
+		fmt.Sprintf("DOCKER_CERT_PATH=%s", dockerCertPath),
+		fmt.Sprintf("DOCKER_TLS_VERIFY=%s", dockerTLSVerify),
+	}
 
 	return &FakeRedisServer{
 		Host:                host,


### PR DESCRIPTION
Add more configs for accessing docker host. When using minikube you need to access docker host from different host(not unix:///var/run/docker.sock) and to pass the certs along with the configuration. This commit allows to pass those vars and to make the testing libs usable with minikube.