### PR TITLE
Close the goroutine on task.Group.Wait on completion

### DIFF
--- a/task/group.go
+++ b/task/group.go
@@ -79,11 +79,10 @@ func (g *Group) Wait(ctx context.Context) error {
 		go func() {
 			select {
 			case <-g.ctx.Done():
+			case <-doneCh:
 				return
 			case <-ctx.Done():
 				g.cancelWithError(ctx.Err())
-			case <-doneCh:
-				return
 			}
 		}()
 	}

--- a/task/group.go
+++ b/task/group.go
@@ -72,6 +72,9 @@ func (g *Group) Go(tasks ...TaskFunc) {
 // Returns the first encountered error if any.
 // If the context is done all tasks are canceled and the context error is returned.
 func (g *Group) Wait(ctx context.Context) error {
+	doneCh := make(chan struct{})
+	defer close(doneCh)
+
 	if ctx != context.TODO() {
 		go func() {
 			select {
@@ -79,6 +82,8 @@ func (g *Group) Wait(ctx context.Context) error {
 				return
 			case <-ctx.Done():
 				g.cancelWithError(ctx.Err())
+			case <-doneCh:
+				return
 			}
 		}()
 	}

--- a/task/group.go
+++ b/task/group.go
@@ -72,15 +72,14 @@ func (g *Group) Go(tasks ...TaskFunc) {
 // Returns the first encountered error if any.
 // If the context is done all tasks are canceled and the context error is returned.
 func (g *Group) Wait(ctx context.Context) error {
-	doneCh := make(chan struct{})
-	defer close(doneCh)
-
 	if ctx != context.TODO() {
+		doneCh := make(chan struct{})
+		defer close(doneCh)
+
 		go func() {
 			select {
 			case <-g.ctx.Done():
 			case <-doneCh:
-				return
 			case <-ctx.Done():
 				g.cancelWithError(ctx.Err())
 			}


### PR DESCRIPTION
### Description
Currently, when we call the `Wait` method of `Group`, the spawned go routine is not closed, unless one of the contexts in the select statement receives something on their `Done` channel, which potentially leads to many unclosed go routines. The issue was discovered by observing a high memory consumption when calling the `Wait` method on one/multiple groups.