### PR TITLE
Add AppendToFile func in OsExecutor

### DIFF
--- a/os/executor.go
+++ b/os/executor.go
@@ -445,9 +445,6 @@ func (ex *RealOsExecutor) AppendToFile(path string, data []byte, perm os.FileMod
 	defer file.Close()
 
 	_, err = file.Write(data)
-	if err != nil {
-		return stacktrace.Propagate(err, "failed to write file: %s", path)
-	}
 
-	return nil
+	return stacktrace.Propagate(err, "failed to write file: %s", path)
 }

--- a/os/executor.go
+++ b/os/executor.go
@@ -435,3 +435,18 @@ func (ex *RealOsExecutor) IsExist(err error) bool {
 func (ex *RealOsExecutor) Rename(oldPath, newPath string) error {
 	return osRename(oldPath, newPath)
 }
+
+func (ex *RealOsExecutor) AppendToFile(path string, data []byte, perm os.FileMode) error {
+	file, err := ex.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, perm)
+	if err != nil {
+		return err
+	}
+
+	defer file.Close()
+
+	if _, err = file.Write(data); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/os/executor.go
+++ b/os/executor.go
@@ -439,13 +439,14 @@ func (ex *RealOsExecutor) Rename(oldPath, newPath string) error {
 func (ex *RealOsExecutor) AppendToFile(path string, data []byte, perm os.FileMode) error {
 	file, err := ex.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, perm)
 	if err != nil {
-		return err
+		return stacktrace.Propagate(err, "failed to open file: %s", path)
 	}
 
 	defer file.Close()
 
-	if _, err = file.Write(data); err != nil {
-		return err
+	_, err = file.Write(data)
+	if err != nil {
+		return stacktrace.Propagate(err, "failed to write file: %s", path)
 	}
 
 	return nil

--- a/os/executor_integration_test.go
+++ b/os/executor_integration_test.go
@@ -292,3 +292,44 @@ func TestRealOsExecutor_RemoveContents(t *testing.T) {
 		},
 	)
 }
+
+func TestRealOsExecutor_AppendToFile(t *testing.T) {
+	t.Run(
+		"when file does not exist, file is created",
+		func(t *testing.T) {
+			osExecutor := &pkgos.RealOsExecutor{}
+
+			dstArg, err := osExecutor.TempDir("", "")
+			require.Nil(t, err, "failed to create temporary dir")
+
+			pathArg := filepath.Join(dstArg, "example.txt")
+
+			err = osExecutor.AppendToFile(pathArg, []byte(""), 0755)
+			require.Nil(t, err)
+
+			_, err = osExecutor.Stat(pathArg)
+			require.Nil(t, err)
+		},
+	)
+
+	t.Run(
+		"when file exists, new content is appended",
+		func(t *testing.T) {
+			osExecutor := &pkgos.RealOsExecutor{}
+
+			dstArg, err := osExecutor.TempDir("", "")
+			require.Nil(t, err, "failed to create temporary dir")
+
+			pathArg := filepath.Join(dstArg, "example.txt")
+
+			err = osExecutor.AppendToFile(pathArg, []byte("old"), 0755)
+			require.Nil(t, err)
+			err = osExecutor.AppendToFile(pathArg, []byte("new"), 0755)
+			require.Nil(t, err)
+
+			fileContent, err := osExecutor.ReadFile(pathArg)
+			require.Nil(t, err)
+			assert.Equal(t, "oldnew", string(fileContent))
+		},
+	)
+}

--- a/os/interface.go
+++ b/os/interface.go
@@ -23,6 +23,7 @@ import (
 
 type (
 	OsExecutor interface {
+		AppendToFile(path string, data []byte, perm os.FileMode) error
 		Args() []string
 		Chdir(dir string) error
 		Chmod(name string, mode os.FileMode) error

--- a/os/ostest/executor.go
+++ b/os/ostest/executor.go
@@ -431,7 +431,7 @@ func (f *FakeOsExecutor) Rename(oldPath, newPath string) error {
 }
 
 func (f *FakeOsExecutor) AppendToFile(path string, data []byte, perm stdOs.FileMode) error {
-	f.Called(path, data, perm)
+	args := f.Called(path, data, perm)
 
-	return nil
+	return args.Error(0)
 }

--- a/os/ostest/executor.go
+++ b/os/ostest/executor.go
@@ -429,3 +429,9 @@ func (f *FakeOsExecutor) Rename(oldPath, newPath string) error {
 
 	return args.Error(0)
 }
+
+func (f *FakeOsExecutor) AppendToFile(path string, data []byte, perm stdOs.FileMode) error {
+	f.Called(path, data, perm)
+
+	return nil
+}


### PR DESCRIPTION
Add functionality to append to file in OsExecutor.

Currently only able to achieve this using OpenFile in combination with Write. The problem with this approach is that OpenFile returns os.File _(pointer to)_ struct which makes it hard to unit test in consuming code.