### PR TITLE
fix(dependencies): use real versions, remove replace

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,12 +2,6 @@ module github.com/sumup-oss/go-pkgs
 
 go 1.24.1
 
-replace (
-	github.com/sumup-oss/go-pkgs/backoff => ./backoff
-	github.com/sumup-oss/go-pkgs/executor/vault => ./executor/vault
-	github.com/sumup-oss/go-pkgs/logger => ./logger
-)
-
 require (
 	github.com/elliotchance/orderedmap v1.2.0
 	github.com/mattes/go-expand-tilde v0.0.0-20150330173918-cb884138e64c
@@ -15,8 +9,8 @@ require (
 	github.com/spf13/cobra v0.0.3
 	github.com/streadway/amqp v0.0.0-20200108173154-1c71cc93ed71
 	github.com/stretchr/testify v1.10.0
-	github.com/sumup-oss/go-pkgs/backoff v0.0.0-00010101000000-000000000000
-	github.com/sumup-oss/go-pkgs/logger v0.0.0-00010101000000-000000000000
+	github.com/sumup-oss/go-pkgs/backoff v1.0.0
+	github.com/sumup-oss/go-pkgs/logger v1.0.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/crypto v0.36.0
 )

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,12 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/sumup-oss/go-pkgs/backoff v1.0.0 h1:8Y87XVIqCOe17p1tndlelblkSvVl5/iH7FchSvrVgKg=
+github.com/sumup-oss/go-pkgs/backoff v1.0.0/go.mod h1:40mvm3dTaoXWyeCYrJ/y0g9hBdQTGYAxKv5xqXOltxI=
 github.com/sumup-oss/go-pkgs/errors v1.0.0 h1:Y93W5Tx96iB4co3gBuuzzFWXG1L8UZ/I/ctQeRagYK0=
 github.com/sumup-oss/go-pkgs/errors v1.0.0/go.mod h1:85LbkrQPwjndGq7rHRBERb4o5Lw6bCLaeuJfD3IQf/0=
+github.com/sumup-oss/go-pkgs/logger v1.0.0 h1:rojUZKMmD78qQvpTDugfyMoUXZlIL3I6phMWwH99jOI=
+github.com/sumup-oss/go-pkgs/logger v1.0.0/go.mod h1:WCCkjXVpCYexQBzmGizN7Cn8TvExGPKIgAk5JnuVQ+s=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=


### PR DESCRIPTION
Using replace resulted in go assigning a pseudo-version `v0.0.0-00010101000000-000000000000` to fake a version for replaced module.
This is an issue as some IDEs(goland) will run `go list -json -m -u -mod=readonly all` which fails and the IDE can't sync the dependencies because of that.