### PR TITLE
feat: extend NewGroup function to accept context

### DIFF
--- a/task/group.go
+++ b/task/group.go
@@ -33,8 +33,8 @@ type Group struct {
 }
 
 // NewGroup creates new task group instance.
-func NewGroup() *Group {
-	ctx, cancel := context.WithCancel(context.Background())
+func NewGroup(ctx context.Context) *Group {
+	ctx, cancel := context.WithCancel(ctx)
 
 	return &Group{
 		ctx:        ctx,

--- a/task/group_test.go
+++ b/task/group_test.go
@@ -56,7 +56,9 @@ func TestGroup_Go(t *testing.T) {
 	t.Run("it runs the tasks", func(t *testing.T) {
 		t.Parallel()
 
-		group := task.NewGroup()
+		ctx := context.Background()
+
+		group := task.NewGroup(ctx)
 		foo := NewTestTask(nil)
 		bar := NewTestTask(nil)
 
@@ -65,7 +67,7 @@ func TestGroup_Go(t *testing.T) {
 		foo.RunUntil <- nil
 		bar.RunUntil <- nil
 
-		err := group.Wait(context.Background())
+		err := group.Wait(ctx)
 		assert.NoError(t, err)
 
 		assert.Equal(t, 1, foo.RunCount)
@@ -77,7 +79,9 @@ func TestGroup_Go(t *testing.T) {
 	t.Run("when a task from the group returns an error, it cancels all the tasks", func(t *testing.T) {
 		t.Parallel()
 
-		group := task.NewGroup()
+		ctx := context.Background()
+
+		group := task.NewGroup(ctx)
 		foo := NewTestTask(assert.AnError)
 		bar := NewTestTask(nil)
 
@@ -90,7 +94,7 @@ func TestGroup_Go(t *testing.T) {
 			foo.RunUntil <- assert.AnError
 		}()
 
-		err := group.Wait(context.Background())
+		err := group.Wait(ctx)
 		assert.EqualError(t, err, assert.AnError.Error())
 
 		assert.Equal(t, 1, foo.RunCount)
@@ -102,7 +106,9 @@ func TestGroup_Go(t *testing.T) {
 	t.Run("when wait deadline is exceeded, it cancels all tasks", func(t *testing.T) {
 		t.Parallel()
 
-		group := task.NewGroup()
+		ctx := context.Background()
+
+		group := task.NewGroup(ctx)
 
 		foo := NewTestTask(assert.AnError)
 		bar := NewTestTask(nil)
@@ -126,7 +132,8 @@ func TestGroup_Go(t *testing.T) {
 	t.Run("when the group is canceled, it does not start new tasks", func(t *testing.T) {
 		t.Parallel()
 
-		group := task.NewGroup()
+		ctx := context.Background()
+		group := task.NewGroup(ctx)
 		foo := NewTestTask(nil)
 		bar := NewTestTask(nil)
 
@@ -147,7 +154,9 @@ func TestGroup_Cancel(t *testing.T) {
 	t.Run("it cancels all the tasks", func(t *testing.T) {
 		t.Parallel()
 
-		group := task.NewGroup()
+		ctx := context.Background()
+
+		group := task.NewGroup(ctx)
 		foo := NewTestTask(nil)
 		bar := NewTestTask(nil)
 
@@ -171,7 +180,9 @@ func TestGroup_Cancel(t *testing.T) {
 }
 
 func BenchmarkGroup_Go(b *testing.B) {
-	group := task.NewGroup()
+	ctx := context.Background()
+
+	group := task.NewGroup(ctx)
 
 	b.ResetTimer()
 	b.ReportAllocs()
@@ -180,5 +191,5 @@ func BenchmarkGroup_Go(b *testing.B) {
 		group.Go(func(ctx context.Context) error { return nil })
 	}
 
-	group.Wait(context.TODO())
+	group.Wait(ctx)
 }


### PR DESCRIPTION
**Why?**

In one of our services we use this library. We configure a context with a logger (example: [cmd/migrate.go](https://github.com/sumup/titanic/blob/main/cmd/migrate.go#L47)), but that context is not propagated to the lower application layers because Group creates a new context from context.Background(). As a result, context values (like the configured logger and its log level) are lost.

This PR extends NewGroup to accept a pre-configured context.Context. Users can then choose whether they want the group to derive from an existing context (preserving values such as the logger) or fall back to context.Background().